### PR TITLE
Use trailing slash to prevent past link breakage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ email: nishiki@hey.com
 description: "Personal blog of a software engineer."
 baseurl: ""
 url: "https://nshki.com"
-permalink: /:title
+permalink: /:title/
 twitter:
   username: nshki_
   card: summary


### PR DESCRIPTION
Links scattered around the Internet for blog posts had trailing slashes, which the newly pushed config broke. This fixes it.