### PR TITLE
Add Etags

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,7 @@
-import { RemixServer } from '@remix-run/react'
 import type { EntryContext } from '@remix-run/node'
+import { RemixServer } from '@remix-run/react'
 import { renderToString } from 'react-dom/server'
+import etag from 'etag'
 
 export default function handleRequest (
   request: Request,
@@ -8,13 +9,18 @@ export default function handleRequest (
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  const markup = renderToString(
+  let markup = renderToString(
     <RemixServer context={remixContext} url={request.url} />
   )
 
-  responseHeaders.set("Content-Type", "text/html")
+  responseHeaders.set('Content-Type', 'text/html')
+  responseHeaders.set('Etag', etag(markup))
 
-  return new Response("<!DOCTYPE html>" + markup, {
+  if (request.headers.get('If-None-Match') === responseHeaders.get('Etag')) {
+    return new Response('', { status: 304, headers: responseHeaders })
+  }
+
+  return new Response('<!DOCTYPE html>' + markup, {
     status: responseStatusCode,
     headers: responseHeaders,
   })

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,4 +1,4 @@
-import type { EntryContext } from '@remix-run/node'
+import type { EntryContext, HandleDataRequestFunction } from '@remix-run/node'
 import { RemixServer } from '@remix-run/react'
 import { renderToString } from 'react-dom/server'
 import etag from 'etag'
@@ -24,4 +24,21 @@ export default function handleRequest (
     status: responseStatusCode,
     headers: responseHeaders,
   })
+}
+
+export const handleDataRequest: HandleDataRequestFunction = async (
+  response: Response,
+  { request }
+) => {
+  let body = await response.text()
+
+  if (request.method.toLowerCase() === 'get') {
+    response.headers.set('etag', etag(body))
+
+    if (request.headers.get('If-None-Match') === response.headers.get('Etag')) {
+      return new Response('', { status: 304, headers: response.headers })
+    }
+  }
+
+  return response;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@remix-run/react": "^1.3.5",
         "@remix-run/vercel": "^1.3.5",
         "@vercel/node": "^1.14.0",
+        "etag": "^1.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rehype-highlight": "^5.0.2"
@@ -18,6 +19,7 @@
         "@remix-run/dev": "^1.3.5",
         "@remix-run/eslint-config": "^1.3.5",
         "@remix-run/serve": "^1.2.3",
+        "@types/etag": "^1.8.1",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
         "eslint": "^8.11.0",
@@ -2500,6 +2502,15 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -6152,7 +6163,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15238,6 +15248,15 @@
         "@types/estree": "*"
       }
     },
+    "@types/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -17896,8 +17915,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-target-shim": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@remix-run/react": "^1.3.5",
     "@remix-run/vercel": "^1.3.5",
     "@vercel/node": "^1.14.0",
+    "etag": "^1.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rehype-highlight": "^5.0.2"
@@ -21,6 +22,7 @@
     "@remix-run/dev": "^1.3.5",
     "@remix-run/eslint-config": "^1.3.5",
     "@remix-run/serve": "^1.2.3",
+    "@types/etag": "^1.8.1",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "eslint": "^8.11.0",


### PR DESCRIPTION
After watching Ryan Florence's excellent [Introduction to HTTP Caching](https://youtu.be/3XkU_DXcgl0) video, I was pretty inspired to implement efficient HTTP caching on my site.

This PR adds ETags to both document and data requests based on parsed markup and text and lets the browser do the rest.

### With Etags

![image](https://user-images.githubusercontent.com/1121087/163079670-424f76b3-88a6-43dc-a940-ad5aceb33e32.png)

### Without Etags

![image](https://user-images.githubusercontent.com/1121087/163079705-f278cb05-0b58-4707-9692-c4116bdfcc08.png)