### PR TITLE
feat(meta): add `fediverse:creator` tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {%- seo %}
     {% assign cache_bust = site.time | date:"?v=%s" %}
+    <meta name="fediverse:creator" content="@nshki@ruby.social">
     <link rel="icon" href="{{ "/favicon.ico" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/base.css" | relative_url | append: cache_bust }}">
     <link rel="stylesheet" href="{{ "/assets/css/components/about.css" | relative_url | append: cache_bust }}">


### PR DESCRIPTION
# Overview

This adds the `fediverse:creator` meta tag to the website so that shares on the fediverse can be traced back to my fedi account.