### PR TITLE
fix(meta): add `fediverse:creator` tag back in

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -8,6 +8,12 @@ useSeoMeta({
 })
 
 useHead({
+  meta: [
+    {
+      name: "fediverse:creator",
+      content: "@nshki@ruby.social"
+    }
+  ],
   link: [
     {
       rel: "alternate",


### PR DESCRIPTION
I missed this in #62. This adds the `fediverse:creator` meta tag back into the site.