### PR TITLE
chore(meta): remove redundant titles

### DIFF
--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -13,10 +13,6 @@ useSeoMeta({
 </script>
 
 <template>
-  <Head>
-    <Title>{{ post?.title }} | Nishiki Liu</Title>
-  </Head>
-
   <div class="post">
     <time :datetime="date.toISOString()">{{ formatDate(date) }}</time>
     <h1>{{ post?.title }}</h1>

--- a/pages/writing.vue
+++ b/pages/writing.vue
@@ -10,10 +10,6 @@ useSeoMeta({
 </script>
 
 <template>
-  <Head>
-    <Title>Writing | Nishiki Liu</Title>
-  </Head>
-
   <h1>Writing</h1>
 
   <Grid>


### PR DESCRIPTION
This removes some redundant `<Title>` components being used in a couple pages. Since I'm using `useSeoMeta()`, they aren't needed.