### PR TITLE
fix(posts): prevent post renders breaking with refreshes

### DIFF
--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 const route = useRoute()
 const { data: posts } = await useAsyncData("posts", () => queryCollection("posts").all())
-const post = posts?.value?.find((post) => post.path.includes(route.path.slice(1)))
+const slug = route.path.split("/").at(1) || ""
+const post = posts?.value?.find((post) => post.path.includes(slug))
 const date = new Date(post?.date ?? "")
 
 useSeoMeta({


### PR DESCRIPTION
This one was a little funky. Some browsers automatically append a `/` at the end of a URL when refreshing the page. This prevented the site from rendering posts properly because of slug extraction logic in `[slug].vue`. This fixes that issue.