### PR TITLE
chore(deps): resolve advisories (2026-01-17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11044,9 +11044,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
+      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
As the title states, this resolves the security advisories posted on 2026-01-17.